### PR TITLE
ctf docker: fix gef

### DIFF
--- a/src/commands/docker/docker-compose.yml
+++ b/src/commands/docker/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - NO_AT_BRIDGE=1  # Couldn't connect to accessibility bus
       - PWNLIB_NOTERM=1
       - PYTHONIOENCODING=utf-8
+      - LC_ALL=C.UTF-8
     working_dir: $PWD
     init: true
     command: sleep inf


### PR DESCRIPTION
Fixes the following error:

    Python Exception <class 'UnicodeEncodeError'> 'ascii' codec can't encode character '\u27a4' in position 12: ordinal not in range(128):