### PR TITLE
ctf docker: add qemu-user

### DIFF
--- a/src/commands/docker/image/Dockerfile
+++ b/src/commands/docker/image/Dockerfile
@@ -30,6 +30,7 @@ RUN apt-get -y update && \
         python3 \
         python3-dev \
         python3-pip \
+        qemu-user \
         strace \
         sudo \
         vim \


### PR DESCRIPTION
Even if the host has qemu-user-binfmt configured, pwntools running inside the container wants a qemu-<arch> binary for running binaries for <arch>.